### PR TITLE
Use ColorManagement better when constructing Colors

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome against localhost",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -8,7 +8,6 @@ import "./index.css";
 extend(THREE);
 
 export const App: Component = () => {
-  // return "hallo";
   return (
     <Canvas camera={{ position: new Vector3(0, 0, 5) }}>
       <T.AmbientLight color={[0.2, 0.2, 0.2]} />

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -8,9 +8,12 @@ import "./index.css";
 extend(THREE);
 
 export const App: Component = () => {
+
+  const ambientColor = new THREE.Color() .setRGB( 0.4, 0.4, 0.4, THREE.LinearSRGBColorSpace );
+
   return (
     <Canvas camera={{ position: new Vector3(0, 0, 5) }}>
-      <T.AmbientLight color={[0.2, 0.2, 0.2]} />
+      <T.AmbientLight color={ambientColor} />
       <T.PointLight intensity={1.2} decay={1} position={[2, 2, 5]} rotation={[0, Math.PI / 3, 0]} />
       <Box />
     </Canvas>

--- a/playground/Box.tsx
+++ b/playground/Box.tsx
@@ -1,5 +1,5 @@
 import { createSignal } from "solid-js";
-import { Mesh } from "three";
+import { Color, Mesh, SRGBColorSpace } from "three";
 import { T, useFrame } from "../src";
 
 export function Box() {
@@ -7,6 +7,9 @@ export function Box() {
   const [hovered, setHovered] = createSignal(false);
 
   useFrame(() => (mesh!.rotation.y += 0.01));
+
+  const green = new Color();
+  green .setStyle( "green", SRGBColorSpace );
 
   return (
     <>
@@ -16,7 +19,7 @@ export function Box() {
         onPointerLeave={e => setHovered(false)}
       >
         <T.BoxGeometry />
-        <T.MeshStandardMaterial color={hovered() ? "green" : "red"} />
+        <T.MeshStandardMaterial color={hovered() ? green : "red" } />
       </T.Mesh>
     </>
   );

--- a/playground/Box.tsx
+++ b/playground/Box.tsx
@@ -1,5 +1,5 @@
 import { createSignal } from "solid-js";
-import { Color, Mesh, SRGBColorSpace } from "three";
+import { Color, LinearSRGBColorSpace, Mesh } from "three";
 import { T, useFrame } from "../src";
 
 export function Box() {
@@ -8,8 +8,8 @@ export function Box() {
 
   useFrame(() => (mesh!.rotation.y += 0.01));
 
-  const green = new Color();
-  green .setStyle( "green", SRGBColorSpace );
+  const green = new Color() .setStyle( "green", LinearSRGBColorSpace );
+  const red = new Color() .setStyle( "red", LinearSRGBColorSpace );
 
   return (
     <>
@@ -19,7 +19,7 @@ export function Box() {
         onPointerLeave={e => setHovered(false)}
       >
         <T.BoxGeometry />
-        <T.MeshStandardMaterial color={hovered() ? green : "red" } />
+        <T.MeshStandardMaterial color={hovered() ? green : red } />
       </T.Mesh>
     </>
   );

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -77,7 +77,7 @@ export interface CanvasProps extends ComponentProps<"div"> {
  * @returns A div element containing the WebGL canvas configured to occupy the full available space.
  */
 export function Canvas(_props: CanvasProps) {
-  const [props, canvasProps] = splitProps(_props, ["fallback", "camera", "children", "ref"]);
+  const [props, canvasProps] = splitProps(_props, ["fallback", "camera", "children", "ref", "linear"]);
   let canvas: HTMLCanvasElement;
   let container: HTMLDivElement;
 

--- a/src/props.ts
+++ b/src/props.ts
@@ -173,24 +173,6 @@ export const applyProp = <T>(source: S3.Instance<T>, type: string, value: any) =
     else if (target instanceof Layers && value instanceof Layers) {
       target.mask = value.mask;
     }
-    else if ( target instanceof Color ) {
-      // value is NOT a Color (would have taken the "Copy" branch)
-      if ( Array.isArray(value) ) {
-        if ( value.length == 2 ) {
-          target .setStyle( ...value );
-        } else if ( value.length == 4 ) {
-          target .setRGB( ...value );
-        } else if ( value.length == 3 ) {
-          target .setRGB( ...value, ColorManagement.workingColorSpace );
-        } else {
-          console.error( `Color properties cannot be set from length-${value.length} arrays` );
-        }
-      } else if ( typeof value === 'string' ) {
-        target .setStyle( value, ColorManagement.workingColorSpace );
-      } else {
-        console.error( `Color properties cannot be set from values of type ${typeof value}` );
-      }
-    }
     // Set array types
     else if (target?.set && Array.isArray(value)) {
       if (target.fromArray) target.fromArray(value);


### PR DESCRIPTION
Solid-three will never set a color without using
ColorManagement.workingColorSpace, or a color space passed to us explicitly.  Mainly, we want to avoid Color setters that default to SRGB, so the user has better control.