### PR TITLE
ci: publish previews to pkg.pr.new on push and PR

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -1,0 +1,33 @@
+name: Publish to pkg.pr.new
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install latest corepack
+        run: npm install corepack@latest -g
+
+      - run: corepack enable
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish preview
+        run: pnpx pkg-pr-new publish --compact


### PR DESCRIPTION
Builds the package and runs `pkg-pr-new publish --compact` so each commit
gets an installable URL (https://pkg.pr.new/<owner>/<repo>@<sha>) without
having to cut a real npm release. Requires the pkg.pr.new GitHub App to be
installed on the repo.
