### PR TITLE
refactor: rename defaultCamera/defaultRaycaster canvas props to camera/raycaster

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ The `Canvas` component initializes the `three.js` rendering context and acts as 
 
 **Props:**
 
-- **defaultCamera**: Configures the camera used in the scene. Can be partial props for a camera or an existing Camera instance.
+- **camera**: Configures the camera used in the scene. Can be partial props for a camera or an existing Camera instance.
 - **fallback**: Element to render while the main content is loading asynchronously.
 - **gl**: Defines options for the WebGLRenderer, a function returning a customized renderer, or an existing renderer instance.
 - **scene**: Provides custom settings for the Scene instance or an existing Scene.
-- **defaultRaycaster**: Configures the Raycaster for mouse and pointer events.
+- **raycaster**: Configures the Raycaster for mouse and pointer events.
 - **shadows**: Enables and configures shadows in the scene with various shadow mapping techniques.
 - **orthographic**: Toggles between Orthographic and Perspective camera for the default camera.
 - **linear**: Toggles linear interpolation for texture filtering.
@@ -122,11 +122,11 @@ The `Canvas` component initializes the `three.js` rendering context and acts as 
 
 ```tsx
 interface CanvasProps {
-  defaultCamera?: Partial<PerspectiveCamera | OrthographicCamera> | Camera
+  camera?: Partial<PerspectiveCamera | OrthographicCamera> | Camera
   fallback?: JSX.Element
   gl?: Partial<WebGLRenderer> | ((canvas: HTMLCanvasElement) => WebGLRenderer) | WebGLRenderer
   scene?: Partial<Scene> | Scene
-  defaultRaycaster?: Partial<Raycaster> | Raycaster
+  raycaster?: Partial<Raycaster> | Raycaster
   shadows?: boolean | "basic" | "percentage" | "soft" | "variance" | WebGLRenderer["shadowMap"]
   orthographic?: boolean
   linear?: boolean
@@ -413,7 +413,7 @@ Provides access to the `three.js` context, including the renderer, scene, camera
 `solid-three` implements a stack-based system for managing its current camera and raycaster:
 
 - **Stack-based Management**: Both cameras and raycasters are managed as stacks internally
-- **Default at Tail**: The `defaultCamera` and `defaultRaycaster` from Canvas props form the tail of their respective stacks
+- **Default at Tail**: The `camera` and `raycaster` from Canvas props form the tail of their respective stacks
 - **Current Active Camera at Head**: The camera/raycaster at the top of the stack is the currently active camera/raycaster
 - **Push To The Stack To Become Active**: By calling `setCamera(camera)` and `setRaycaster(raycaster)`, the camera/raycaster is pushed to the stack. This causes it to become the currently active camera/raycaster
 - **Pop From The Stack To Deactivate**: `setCamera(camera)` and `setRaycaster(raycaster)` return a cleanup-function to pop the camera/raycaster from the stack. If the camera/raycaster was on top of the stack, the previous camera/raycaster in the stack becomes active again
@@ -745,7 +745,7 @@ const App = () => {
   const raycaster = new CursorRaycaster()
 
   // CursorRaycaster is used by default, but you can explicitly set it:
-  return <Canvas defaultRaycaster={raycaster}>{/* Your scene */}</Canvas>
+  return <Canvas raycaster={raycaster}>{/* Your scene */}</Canvas>
 }
 ```
 
@@ -760,7 +760,7 @@ import { CenterRaycaster } from "solid-three"
 const App = () => {
   const raycaster = new CenterRaycaster()
 
-  return <Canvas defaultRaycaster={raycaster}>>{/* Your scene */}</Canvas>
+  return <Canvas raycaster={raycaster}>>{/* Your scene */}</Canvas>
 }
 ```
 
@@ -796,7 +796,7 @@ class CustomRaycaster extends Raycaster implements EventRaycaster {
 const App = () => {
   const raycaster = new CustomRaycaster()
 
-  return <Canvas defaultRaycaster={raycaster}>{/* Your scene */}</Canvas>
+  return <Canvas raycaster={raycaster}>{/* Your scene */}</Canvas>
 }
 ```
 
@@ -1118,7 +1118,7 @@ const TreePropagation = () => {
 ```tsx
 const RayPropagation = () => {
   return (
-    <Canvas defaultCamera={{ position: [0, 0, 5] }}>
+    <Canvas camera={{ position: [0, 0, 5] }}>
       <T.Mesh
         name="front mesh"
         position={[0, 0, 2]}

--- a/playground/App.tsx
+++ b/playground/App.tsx
@@ -150,7 +150,7 @@ export function App() {
         path="/"
         component={() => (
           <Canvas
-            defaultCamera={{ position: new THREE.Vector3(0, 0, 15) }}
+            camera={{ position: new THREE.Vector3(0, 0, 15) }}
             scene={{ background: [0.1, 0.1, 0.15] }}
             class="home-canvas"
           >

--- a/playground/src/api/autodispose/basic-usage.tsx
+++ b/playground/src/api/autodispose/basic-usage.tsx
@@ -32,7 +32,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/autodispose/conditional-rendering.tsx
+++ b/playground/src/api/autodispose/conditional-rendering.tsx
@@ -42,7 +42,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/autodispose/shared-resources.tsx
+++ b/playground/src/api/autodispose/shared-resources.tsx
@@ -46,7 +46,7 @@ export default function () {
         </section>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
         <Index each={Array.from({ length: instanceCount() })}>

--- a/playground/src/api/canvas/usage.tsx
+++ b/playground/src/api/canvas/usage.tsx
@@ -58,7 +58,7 @@ export default function () {
       </details>
 
       <Canvas
-        defaultCamera={{
+        camera={{
           position: orthographic() ? [5, 5, 5] : [0, 0, 5],
           fov: 75,
         }}
@@ -70,7 +70,7 @@ export default function () {
           background: new THREE.Color(0x202020),
           fog: new THREE.Fog(0x202020, 10, 50),
         }}
-        defaultRaycaster={{
+        raycaster={{
           params: {
             Mesh: {},
             Line: { threshold: 0.1 },

--- a/playground/src/api/entity/advanced-props.tsx
+++ b/playground/src/api/entity/advanced-props.tsx
@@ -29,7 +29,7 @@ export default function () {
         <p>Kebab-case props like position-x automatically map to object.position.x = value.</p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <Entity from={THREE.AmbientLight} args={[0.4]} />
         <Entity from={THREE.PointLight} position={[10, 10, 10]} args={[0xffffff, 0.8]} />
 

--- a/playground/src/api/entity/constructor-usage.tsx
+++ b/playground/src/api/entity/constructor-usage.tsx
@@ -29,7 +29,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <Entity from={THREE.AmbientLight} args={[0.5]} />
         <Entity from={THREE.PointLight} position={[10, 10, 10]} args={[0xffffff, 0.8]} />
 

--- a/playground/src/api/entity/instance-usage.tsx
+++ b/playground/src/api/entity/instance-usage.tsx
@@ -37,7 +37,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <Entity from={THREE.AmbientLight} args={[0.5]} />
         <Entity from={THREE.PointLight} position={[10, 10, 10]} args={[0xffffff, 0.8]} />
 

--- a/playground/src/api/events/click-outside.tsx
+++ b/playground/src/api/events/click-outside.tsx
@@ -42,7 +42,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas style={{ width: "100%", height: "100%" }} defaultCamera={{ position: [0, 0, 5] }}>
+      <Canvas style={{ width: "100%", height: "100%" }} camera={{ position: [0, 0, 5] }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/events/event-propagation.tsx
+++ b/playground/src/api/events/event-propagation.tsx
@@ -39,7 +39,7 @@ export default function () {
 
       <Canvas
         onClick={() => console.info("4. Canvas clicked (canvas propagation)")}
-        defaultCamera={{ position: [0, 0, 8] }}
+        camera={{ position: [0, 0, 8] }}
         style={{ width: "100%", height: "100%" }}
       >
         <T.AmbientLight intensity={0.5} />

--- a/playground/src/api/events/overview.tsx
+++ b/playground/src/api/events/overview.tsx
@@ -281,7 +281,7 @@ export default function () {
       </details>
 
       <Canvas
-        defaultCamera={{ position: [0, 0, 8] }}
+        camera={{ position: [0, 0, 8] }}
         style={{ width: "100%", height: "100%" }}
         onClick={() => console.info("Canvas clicked (canvas propagation)")}
         onClickMissed={() => console.info("Clicked empty space")}

--- a/playground/src/api/events/raycast-blocking.tsx
+++ b/playground/src/api/events/raycast-blocking.tsx
@@ -59,7 +59,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/events/raycastable-prop.tsx
+++ b/playground/src/api/events/raycastable-prop.tsx
@@ -38,7 +38,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/portal/usage.tsx
+++ b/playground/src/api/portal/usage.tsx
@@ -50,7 +50,7 @@ export default function () {
 
       <Canvas
         style={{ width: "100%", height: "100%" }}
-        defaultCamera={{ position: new THREE.Vector3(0, 0, 30) }}
+        camera={{ position: new THREE.Vector3(0, 0, 30) }}
         onClick={event => console.debug("canvas clicked", event)}
         onClickMissed={event => console.debug("canvas click missed", event)}
         onPointerLeave={event => console.debug("canvas pointer leave", event)}

--- a/playground/src/api/raycaster/usage.tsx
+++ b/playground/src/api/raycaster/usage.tsx
@@ -96,8 +96,8 @@ export default function () {
       </details>
 
       <Canvas
-        defaultRaycaster={getRaycaster()}
-        defaultCamera={{ position: [0, 0, 8] }}
+        raycaster={getRaycaster()}
+        camera={{ position: [0, 0, 8] }}
         style={{ width: "100%", height: "100%" }}
         onPointerMove={() => {
           // This will trigger raycaster updates

--- a/playground/src/api/resource/usage.tsx
+++ b/playground/src/api/resource/usage.tsx
@@ -42,7 +42,7 @@ export default function () {
 
       <Canvas
         style={{ width: "100%", height: "100%" }}
-        defaultCamera={{ position: new THREE.Vector3(0, 0, 3) }}
+        camera={{ position: new THREE.Vector3(0, 0, 3) }}
       >
         <Entity from={THREE.AmbientLight} />
         <Resource

--- a/playground/src/api/t/complete-three.tsx
+++ b/playground/src/api/t/complete-three.tsx
@@ -34,7 +34,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 8] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 8] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/t/tree-shaking.tsx
+++ b/playground/src/api/t/tree-shaking.tsx
@@ -40,7 +40,7 @@ export default function () {
         </ul>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 8] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 8] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
         <T.Mesh ref={sphereRef} position={[2, 0, 0]}>

--- a/playground/src/api/use-frame/usage.tsx
+++ b/playground/src/api/use-frame/usage.tsx
@@ -48,7 +48,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/use-loader/render-function.tsx
+++ b/playground/src/api/use-loader/render-function.tsx
@@ -59,7 +59,7 @@ export default function () {
 
       <Canvas
         style={{ width: "100%", height: "100%" }}
-        defaultCamera={{ position: new THREE.Vector3(0, 0, 3) }}
+        camera={{ position: new THREE.Vector3(0, 0, 3) }}
       >
         <Entity from={THREE.AmbientLight} />
         <Entity from={resource()?.scene.children[0]} />

--- a/playground/src/api/use-loader/single-texture.tsx
+++ b/playground/src/api/use-loader/single-texture.tsx
@@ -60,7 +60,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 3] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 3] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.2} />
 
         <Suspense

--- a/playground/src/api/use-loader/texture-record.tsx
+++ b/playground/src/api/use-loader/texture-record.tsx
@@ -54,7 +54,7 @@ export default function () {
         </p>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.3} />
         <T.DirectionalLight position={[5, 5, 5]} intensity={1} />
 

--- a/playground/src/api/use-props/usage.tsx
+++ b/playground/src/api/use-props/usage.tsx
@@ -51,7 +51,7 @@ export default function () {
         </ul>
       </details>
 
-      <Canvas defaultCamera={{ position: [0, 0, 8] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 8] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} intensity={0.8} />
 

--- a/playground/src/api/use-three/camera-switch.tsx
+++ b/playground/src/api/use-three/camera-switch.tsx
@@ -64,7 +64,7 @@ export default function () {
         </button>
       </div>
 
-      <Canvas defaultCamera={{ position: [0, 0, 5] }}>
+      <Canvas camera={{ position: [0, 0, 5] }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} />
 

--- a/playground/src/api/use-three/manual-render.tsx
+++ b/playground/src/api/use-three/manual-render.tsx
@@ -83,7 +83,7 @@ export default function () {
       </details>
 
       <Canvas
-        defaultCamera={{ position: [0, 0, 5] }}
+        camera={{ position: [0, 0, 5] }}
         frameloop="demand"
         style={{ width: "100%", height: "100%" }}
       >

--- a/playground/src/api/use-three/overview.tsx
+++ b/playground/src/api/use-three/overview.tsx
@@ -47,7 +47,7 @@ function Overview() {
 export default function () {
   return (
     <div ref={container!}>
-      <Canvas defaultCamera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
+      <Canvas camera={{ position: [0, 0, 5] }} style={{ width: "100%", height: "100%" }}>
         <T.AmbientLight intensity={0.5} />
         <T.PointLight position={[10, 10, 10]} />
 

--- a/playground/src/examples/environment.tsx
+++ b/playground/src/examples/environment.tsx
@@ -9,7 +9,7 @@ export default function () {
   return (
     <Canvas
       style={{ width: "100vw", height: "100vh" }}
-      defaultCamera={{ position: new THREE.Vector3(0, 0, 30) }}
+      camera={{ position: new THREE.Vector3(0, 0, 30) }}
       onClick={event => console.debug("canvas clicked", event)}
       onClickMissed={event => console.debug("canvas click missed", event)}
       onPointerLeave={event => console.debug("canvas pointer leave", event)}

--- a/playground/src/examples/solar.tsx
+++ b/playground/src/examples/solar.tsx
@@ -120,7 +120,7 @@ function CelestialBody(
 export default function () {
   return (
     <Canvas
-      defaultCamera={{ position: new THREE.Vector3(0, 0, 30) }}
+      camera={{ position: new THREE.Vector3(0, 0, 30) }}
       onClick={event => console.debug("canvas clicked", event)}
       onClickMissed={event => console.debug("canvas click missed", event)}
       onPointerLeave={event => console.debug("canvas pointer leave", event)}

--- a/src/canvas.tsx
+++ b/src/canvas.tsx
@@ -19,9 +19,9 @@ export interface CanvasProps extends ParentProps<Partial<CanvasEventHandlers>> {
   ref?: Ref<Context>
   class?: string
   /** Configuration for the camera used in the scene. */
-  defaultCamera?: Partial<Props<PerspectiveCamera> | Props<OrthographicCamera>> | Camera
+  camera?: Partial<Props<PerspectiveCamera> | Props<OrthographicCamera>> | Camera
   /** Configuration for the Raycaster used for mouse and pointer events. */
-  defaultRaycaster?: Partial<Props<EventRaycaster>> | EventRaycaster | Raycaster
+  raycaster?: Partial<Props<EventRaycaster>> | EventRaycaster | Raycaster
   /** Element to render while the main content is loading asynchronously.  */
   fallback?: JSX.Element
   /** Toggles flat interpolation for texture filtering. */

--- a/src/create-three.tsx
+++ b/src/create-three.tsx
@@ -169,16 +169,16 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
   /*                                                                                */
   /**********************************************************************************/
 
-  const defaultCamera = createMemo(() =>
+  const camera = createMemo(() =>
     meta(
-      props.defaultCamera instanceof Camera
-        ? (props.defaultCamera as OrthographicCamera | PerspectiveCamera)
+      props.camera instanceof Camera
+        ? (props.camera as OrthographicCamera | PerspectiveCamera)
         : props.orthographic
         ? new OrthographicCamera()
         : new PerspectiveCamera(),
       {
         get props() {
-          return props.defaultCamera || {}
+          return props.camera || {}
         },
       },
     ),
@@ -193,12 +193,12 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
     }),
   )
 
-  const defaultRaycaster = createMemo(() =>
+  const raycaster = createMemo(() =>
     meta<Raycaster | EventRaycaster>(
-      props.defaultRaycaster instanceof Raycaster ? props.defaultRaycaster : new CursorRaycaster(),
+      props.raycaster instanceof Raycaster ? props.raycaster : new CursorRaycaster(),
       {
         get props() {
-          return props.defaultRaycaster || {}
+          return props.raycaster || {}
         },
       },
     ),
@@ -229,7 +229,7 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
 
   const defaultTarget = new Vector3()
   const viewport = createMemo(() =>
-    getCurrentViewport(defaultCamera(), defaultTarget, measure.bounds()),
+    getCurrentViewport(camera(), defaultTarget, measure.bounds()),
   )
 
   const clock = new Clock()
@@ -253,7 +253,7 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
     xr,
     // elements
     get camera() {
-      return cameraStack.peek() ?? defaultCamera()
+      return cameraStack.peek() ?? camera()
     },
     setCamera(camera: CameraKind) {
       return cameraStack.push(camera)
@@ -262,7 +262,7 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
       return scene()
     },
     get raycaster() {
-      return raycasterStack.peek() || defaultRaycaster()
+      return raycasterStack.peek() || raycaster()
     },
     setRaycaster(raycaster: Raycaster) {
       return raycasterStack.push(raycaster)
@@ -299,11 +299,11 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
     // Manage camera
     createRenderEffect(() => {
       if (cameraStack.peek()) return
-      if (!props.defaultCamera || props.defaultCamera instanceof Camera) return
-      useProps(defaultCamera, props.defaultCamera)
+      if (!props.camera || props.camera instanceof Camera) return
+      useProps(camera, props.camera)
       // NOTE:  Manually update camera's matrix with updateMatrixWorld is needed.
       //        Otherwise casting a ray immediately after start-up will cause the incorrect matrix to be used.
-      defaultCamera().updateMatrixWorld(true)
+      camera().updateMatrixWorld(true)
     })
 
     // Manage scene
@@ -314,8 +314,8 @@ export function createThree(canvas: HTMLCanvasElement, props: CanvasProps) {
 
     // Manage raycaster
     createRenderEffect(() => {
-      if (!props.defaultRaycaster || props.defaultRaycaster instanceof Raycaster) return
-      useProps(defaultRaycaster, props.defaultRaycaster)
+      if (!props.raycaster || props.raycaster instanceof Raycaster) return
+      useProps(raycaster, props.raycaster)
     })
 
     // Manage gl

--- a/src/testing/index.tsx
+++ b/src/testing/index.tsx
@@ -33,7 +33,7 @@ export function test(
           get children() {
             return children()
           },
-          defaultCamera: {
+          camera: {
             position: [0, 0, 5] as [number, number, number],
           },
         },

--- a/tests/core/renderer.test.tsx
+++ b/tests/core/renderer.test.tsx
@@ -461,7 +461,7 @@ describe("renderer", () => {
 
     camera = test(() => <T.Group />, {
       orthographic: true,
-      defaultCamera: { position: [0, 0, 5] },
+      camera: { position: [0, 0, 5] },
     }).camera
 
     expect(camera.type).toEqual("OrthographicCamera")


### PR DESCRIPTION
## Summary

Renames the `<Canvas>` props `defaultCamera` and `defaultRaycaster` to `camera` and `raycaster`.

The default prefix was chosen to reflect how these props work internally: the canvas maintains a stack for both the active camera and raycaster, and these props seed the bottom of that stack — the fallback that's active unless something higher in the scene graph (e.g. a portal) pushes its own onto the stack.

While accurate, the default prefix turns out to be an implementation detail that leaks into the public API. From a user's perspective, camera and raycaster are simply "the camera/raycaster to use for this canvas" — the stack mechanism is invisible. The longer names also create friction for the common case where users just want to supply a custom camera without thinking about stacks at all.

##  Changes

- Renames defaultCamera → camera and defaultRaycaster → raycaster on <Canvas> props
- Updates all playground examples, tests, and README to use the new names

##  Breaking change

This is a rename-only breaking change. No behavior is altered. Users on the previous API need to rename their props.