### PR TITLE
fix(props): assign ref before mounting children

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -365,6 +365,16 @@ export function useProps<T extends Record<string, any>>(
 ) {
   const [local, instanceProps] = splitProps(props, ["ref", "args", "object", "attach", "children"])
 
+  // Assign the ref before mounting children, so a child can read this element's ref
+  // in a reactive binding during its own render — matching Solid DOM, which assigns
+  // refs before inserting children (see the "ref timing" test).
+  createRenderEffect(() => {
+    const object = resolve(accessor)
+    if (!object) return
+    if (local.ref instanceof Function) local.ref(object)
+    else local.ref = object
+  })
+
   useSceneGraph(accessor, props)
 
   createRenderEffect(() => {
@@ -383,12 +393,6 @@ export function useProps<T extends Record<string, any>>(
       const childMeta = getMeta(object)
       if (childMeta) childMeta.ctx = context as Context
     }
-
-    // Assign ref
-    createRenderEffect(() => {
-      if (local.ref instanceof Function) local.ref(object)
-      else local.ref = object
-    })
 
     // Apply the props to THREE-instance
     createRenderEffect(() => {

--- a/tests/core/ref-timing.test.tsx
+++ b/tests/core/ref-timing.test.tsx
@@ -1,0 +1,34 @@
+import { createRenderEffect } from "solid-js"
+import * as THREE from "three"
+import { describe, expect, it } from "vitest"
+import { createT } from "../../src/index.ts"
+import { test } from "../../src/testing/index.tsx"
+
+const T = createT(THREE)
+
+describe("ref timing", () => {
+  // Matches Solid DOM: a parent's ref must be assigned BEFORE its children mount,
+  // so a child can read the parent ref in a reactive binding during its own render.
+  it("a child sees the parent's ref during its own render", () => {
+    let parent: THREE.Mesh | undefined
+    let seenByChild: THREE.Object3D | undefined
+
+    const Child = (props: { parent: () => THREE.Mesh | undefined }) => {
+      // Runs during the child's creation, like a reactive prop binding would.
+      createRenderEffect(() => (seenByChild = props.parent()))
+      return <T.MeshBasicMaterial />
+    }
+
+    test(() => (
+      <T.Mesh ref={parent}>
+        <T.BoxGeometry args={[2, 2]} />
+        <Child parent={() => parent} />
+      </T.Mesh>
+    ))
+
+    expect({ parentAssigned: parent != null, childSawParent: seenByChild === parent }).toEqual({
+      parentAssigned: true,
+      childSawParent: true,
+    })
+  })
+})


### PR DESCRIPTION
`useProps` assigned an element's `ref` in a `createRenderEffect` that ran *after* `useSceneGraph` had already resolved and mounted the element's children. So a child reading the parent's ref in a reactive binding saw `undefined` on its first run and — since a plain `let` ref isn't reactive — never updated. This diverges from Solid DOM, which assigns refs before inserting children.

The fix moves the ref assignment ahead of `useSceneGraph`, so it lands before children mount.

**Repro:** a descendant binding that reads an ancestor's ref (e.g. a material `color` keyed off the parent mesh's ref) stays stuck at its initial value; the plain-Solid-DOM equivalent works.

**Test:** `tests/core/ref-timing.test.tsx` — "a child sees the parent's ref during its own render" (fails before, passes after).